### PR TITLE
Fix leap-day glitch in 01-basic.t (RT:112762)

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -120,20 +120,20 @@ TODO: {
     $dt = DateTimeX::Easy->new("last monday");
     ok($dt);
 
-    # ... but in 1969:
-    $dt = DateTimeX::Easy->new("last monday", year => 1969);
+    # ... but in 1968:
+    $dt = DateTimeX::Easy->new("last monday", year => 1968);
     ok($dt);
 
     # ... at the 100th nanosecond:
-    $dt = DateTimeX::Easy->new("last monday", year => 1969, nanosecond => 100);
+    $dt = DateTimeX::Easy->new("last monday", year => 1968, nanosecond => 100);
     ok($dt);
 
     # ... in US/Eastern: (This will NOT do a timezone conversion)
-    $dt = DateTimeX::Easy->new("last monday", year => 1969, nanosecond => 100, timezone => "US/Eastern");
+    $dt = DateTimeX::Easy->new("last monday", year => 1968, nanosecond => 100, timezone => "US/Eastern");
     ok($dt);
 
     # This WILL do a proper timezone conversion:
-    $dt = DateTimeX::Easy->new("last monday", year => 1969, nanosecond => 100, timezone => "US/Pacific");
+    $dt = DateTimeX::Easy->new("last monday", year => 1968, nanosecond => 100, timezone => "US/Pacific");
     $dt->set_time_zone("America/New_York");
     ok($dt);
 }


### PR DESCRIPTION
For the week of 2016-03-06 to 2016-03-12, "last monday" is Feb 29.

Feb 29 1969 is of course an invalid date, so I've switched it to the
nearest leap year.

See also: https://rt.cpan.org/Ticket/Display.html?id=112762
