### PR TITLE
Use leap year in tests

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -120,20 +120,20 @@ TODO: {
     $dt = DateTimeX::Easy->new("last monday");
     ok($dt);
 
-    # ... but in 1969:
-    $dt = DateTimeX::Easy->new("last monday", year => 1969);
+    # ... but in 1968:
+    $dt = DateTimeX::Easy->new("last monday", year => 1968);
     ok($dt);
 
     # ... at the 100th nanosecond:
-    $dt = DateTimeX::Easy->new("last monday", year => 1969, nanosecond => 100);
+    $dt = DateTimeX::Easy->new("last monday", year => 1968, nanosecond => 100);
     ok($dt);
 
     # ... in US/Eastern: (This will NOT do a timezone conversion)
-    $dt = DateTimeX::Easy->new("last monday", year => 1969, nanosecond => 100, timezone => "US/Eastern");
+    $dt = DateTimeX::Easy->new("last monday", year => 1968, nanosecond => 100, timezone => "US/Eastern");
     ok($dt);
 
     # This WILL do a proper timezone conversion:
-    $dt = DateTimeX::Easy->new("last monday", year => 1969, nanosecond => 100, timezone => "US/Pacific");
+    $dt = DateTimeX::Easy->new("last monday", year => 1968, nanosecond => 100, timezone => "US/Pacific");
     $dt->set_time_zone("America/New_York");
     ok($dt);
 }


### PR DESCRIPTION
Hello.

This module can't be installed _during this week_ since the “last monday” was a leap day (February 29) and there is _no leap day_ in 1969.

We will encounter this problem in 2044 again.

I suppose using any leap year is a good decision.
