### PR TITLE
Fix for failing tests on install of DateTimeX-Easy

### DIFF
--- a/t/03-parse.t
+++ b/t/03-parse.t
@@ -19,15 +19,15 @@ $yyy-12-21T17:05:00 | 21 dec 17:05
 $yyy-12-21T17:05:00 | 21-dec 17:05
 $yyy-12-21T17:05:00 | 21/dec 17:05
 1993-12-21T17:05:00 | 21/dec/93 17:05
-1999-01-01T10:02:18 @ UTC | 1999 10:02:18 "GMT"
+1999-01-01T10:02:18 | 1999 10:02:18 "GMT"
 1994-11-16T22:28:20 @ -0800 | 16 Nov 94 22:28:20 PST
 _END_
     next if m/^\s*#/;
     my ($want, $from) = split m/\s*\|\s*/, $_, 2;
     my ($want_dt, $want_tz) = split m/\s*\@\s*/, $want, 2;
-    $want_tz ||= "floating";
+    $want_tz ||= "+0000";
 
     my $dt = DateTimeX::Easy->new($from);
     is($dt, $want_dt);
-    is($dt->time_zone->name, $want_tz);
+    is($dt->strftime(q{%z}), $want_tz);
 }


### PR DESCRIPTION
When trying to install DateTimeX::Easy on both CentOS and AWS Linux containers starting around (2021-07-08), the following test error is encountered (note: you can install with the force option, but of course this is not preferrable):

```
#   Failed test at t/03-parse.t line 32.
#          got: 'America/New_York'
#     expected: '-0500'
# Looks like you failed 1 test of 18.
t/03-parse.t ..... Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/18 subtests

```

**NOTE: Thanks to Petr Pisar for the following investigation / fix**
After upgrading DateTime-Format-Flexible from 0.33 to 0.34, a test fails like this:

    t/03-parse.t ..... 1/?
    #   Failed test at t/03-parse.t line 32.
    #          got: 'America/New_York'
    #     expected: '-0500'
    # Looks like you failed 1 test of 18.
    t/03-parse.t ..... Dubious, test returned 1 (wstat 256, 0x100)

That's because new DateTime::Format::Flexible started to support time zones enclosed in parenthesis and the teste string was "Wed, 9 Nov 1994 09:50:32 -0500 (EST)".

I conclude that the test is broken because $DateTime->time_zone->name is allowed to return a label instead of an offest. So I corrected thetest to compare an offset value.

The reason why this emerged now is that DateTimeX::Easy ignores almost all DateTime::Format::Flexible return values because it plays with time zones a bad way.